### PR TITLE
Show how to track session end with a UNIX timestamp on users.

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -4,5 +4,5 @@ Packaging
 To package the project template to be shared with game teams over email use:
 
 ```shell
-zip -r nakama-project-template.zip Dockerfile LICENSE README.md daily_rewards.go docker-compose.yml go.mod go.sum local.yml main.go daily_rewards.lua main.lua sessions.go sessions.lua
+zip -r nakama-project-template.zip Dockerfile LICENSE README.md daily_rewards.go daily_rewards.lua api docker-compose.yml go.mod go.sum local.yml main.go main.lua match_handler.go match_rpc.go sessions.go sessions.lua single_device.go
 ```

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func InitModule(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runti
 		return err
 	}
 
-	if err := SingleDeviceLimiter(nk, initializer); err != nil {
+	if err := registerSessionEvents(db, nk, initializer); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
A small new example on how to track a timestamp for each user when they close their socket. This is often used in games to show a "recently active" moment next to players on the friends list.