### PR TITLE
Update match_handler.ts

### DIFF
--- a/match_handler.ts
+++ b/match_handler.ts
@@ -384,7 +384,7 @@ function winCheck(board: Board, mark: Mark): [boolean, Mark[] | null] {
 function connectedPlayers(s: State): number {
     let count = 0;
     for(const p of Object.keys(s.presences)) {
-        if (p !== null) {
+        if (s.presences[p] !== null) {
             count++;
         }
     }


### PR DESCRIPTION
fixed a bug in connectedPlayers() where players who had disconnected were still being counted by this function